### PR TITLE
Sync changes from indexmap and release 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.2.6", default-features = false }
+indexmap = { version = "2.3.0", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "0.5.0"
+version = "0.5.1"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 0.5.1
+
+- Added trait `MutableEntryKey` for opt-in mutable access to map entry keys.
+- Added method `MutableKeys::iter_mut2` for opt-in mutable iteration of map
+  keys and values.
+
 ## 0.5.0
 
 - Reinstated `ordermap` as a crate that wraps `indexmap` with stronger

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! `default-features = false` to your dependency specification.
 //!
 //! - Creating maps and sets using [`new`][OrderMap::new] and
-//! [`with_capacity`][OrderMap::with_capacity] is unavailable without `std`.
+//!   [`with_capacity`][OrderMap::with_capacity] is unavailable without `std`.
 //!   Use methods [`OrderMap::default`], [`with_hasher`][OrderMap::with_hasher],
 //!   [`with_capacity_and_hasher`][OrderMap::with_capacity_and_hasher] instead.
 //!   A no-std compatible hasher will be needed as well, for example

--- a/src/map.rs
+++ b/src/map.rs
@@ -28,7 +28,8 @@ pub use self::mutable::MutableEntryKey;
 pub use self::mutable::MutableKeys;
 pub use self::raw_entry_v1::RawEntryApiV1;
 pub use indexmap::map::{
-    Drain, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Slice, Splice, Values, ValuesMut,
+    Drain, IntoIter, IntoKeys, IntoValues, Iter, IterMut, IterMut2, Keys, Slice, Splice, Values,
+    ValuesMut,
 };
 
 #[cfg(feature = "rayon")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -24,6 +24,7 @@ pub mod serde_seq;
 mod tests;
 
 pub use self::entry::{Entry, IndexedEntry, OccupiedEntry, VacantEntry};
+pub use self::mutable::MutableEntryKey;
 pub use self::mutable::MutableKeys;
 pub use self::raw_entry_v1::RawEntryApiV1;
 pub use indexmap::map::{

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -121,7 +121,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Entry<'_, K, V> {
 /// A view into an occupied entry in an [`OrderMap`][crate::OrderMap].
 /// It is part of the [`Entry`] enum.
 pub struct OccupiedEntry<'a, K, V> {
-    inner: ix::OccupiedEntry<'a, K, V>,
+    pub(crate) inner: ix::OccupiedEntry<'a, K, V>,
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
@@ -253,7 +253,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for OccupiedEntry<'_, K, V> {
 /// A view into a vacant entry in an [`OrderMap`][crate::OrderMap].
 /// It is part of the [`Entry`] enum.
 pub struct VacantEntry<'a, K, V> {
-    inner: ix::VacantEntry<'a, K, V>,
+    pub(crate) inner: ix::VacantEntry<'a, K, V>,
 }
 
 impl<'a, K, V> VacantEntry<'a, K, V> {
@@ -315,7 +315,7 @@ impl<K: fmt::Debug, V> fmt::Debug for VacantEntry<'_, K, V> {
 ///
 /// This `struct` is created from the [`get_index_entry`][crate::OrderMap::get_index_entry] method.
 pub struct IndexedEntry<'a, K, V> {
-    inner: ix::IndexedEntry<'a, K, V>,
+    pub(crate) inner: ix::IndexedEntry<'a, K, V>,
 }
 
 impl<'a, K, V> IndexedEntry<'a, K, V> {

--- a/src/map/mutable.rs
+++ b/src/map/mutable.rs
@@ -1,5 +1,6 @@
-use super::{Equivalent, OrderMap};
+use super::{Entry, Equivalent, IndexedEntry, OccupiedEntry, OrderMap, VacantEntry};
 use core::hash::{BuildHasher, Hash};
+use indexmap::map::MutableEntryKey as _;
 use indexmap::map::MutableKeys as _;
 
 /// Opt-in mutable access to [`OrderMap`] keys.
@@ -75,8 +76,77 @@ where
     }
 }
 
+/// Opt-in mutable access to [`Entry`] keys.
+///
+/// These methods expose `&mut K`, mutable references to the key as it is stored
+/// in the map.
+/// You are allowed to modify the keys in the map **if the modification
+/// does not change the key’s hash and equality**.
+///
+/// If keys are modified erroneously, you can no longer look them up.
+/// This is sound (memory safe) but a logical error hazard (just like
+/// implementing `PartialEq`, `Eq`, or `Hash` incorrectly would be).
+///
+/// `use` this trait to enable its methods for `Entry`.
+///
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait MutableEntryKey: private::Sealed {
+    type Key;
+    fn key_mut(&mut self) -> &mut Self::Key;
+}
+
+/// Opt-in mutable access to [`Entry`] keys.
+///
+/// See [`MutableEntryKey`] for more information.
+impl<K, V> MutableEntryKey for Entry<'_, K, V> {
+    type Key = K;
+
+    /// Gets a mutable reference to the entry's key, either within the map if occupied,
+    /// or else the new key that was used to find the entry.
+    fn key_mut(&mut self) -> &mut Self::Key {
+        match self {
+            Entry::Occupied(e) => e.key_mut(),
+            Entry::Vacant(e) => e.key_mut(),
+        }
+    }
+}
+
+/// Opt-in mutable access to [`OccupiedEntry`] keys.
+///
+/// See [`MutableEntryKey`] for more information.
+impl<K, V> MutableEntryKey for OccupiedEntry<'_, K, V> {
+    type Key = K;
+    fn key_mut(&mut self) -> &mut Self::Key {
+        self.inner.key_mut()
+    }
+}
+
+/// Opt-in mutable access to [`VacantEntry`] keys.
+///
+/// See [`MutableEntryKey`] for more information.
+impl<K, V> MutableEntryKey for VacantEntry<'_, K, V> {
+    type Key = K;
+    fn key_mut(&mut self) -> &mut Self::Key {
+        self.inner.key_mut()
+    }
+}
+
+/// Opt-in mutable access to [`IndexedEntry`] keys.
+///
+/// See [`MutableEntryKey`] for more information.
+impl<K, V> MutableEntryKey for IndexedEntry<'_, K, V> {
+    type Key = K;
+    fn key_mut(&mut self) -> &mut Self::Key {
+        self.inner.key_mut()
+    }
+}
+
 mod private {
     pub trait Sealed {}
 
     impl<K, V, S> Sealed for super::OrderMap<K, V, S> {}
+    impl<K, V> Sealed for super::Entry<'_, K, V> {}
+    impl<K, V> Sealed for super::OccupiedEntry<'_, K, V> {}
+    impl<K, V> Sealed for super::VacantEntry<'_, K, V> {}
+    impl<K, V> Sealed for super::IndexedEntry<'_, K, V> {}
 }

--- a/src/map/mutable.rs
+++ b/src/map/mutable.rs
@@ -1,4 +1,4 @@
-use super::{Entry, Equivalent, IndexedEntry, OccupiedEntry, OrderMap, VacantEntry};
+use super::{Entry, Equivalent, IndexedEntry, IterMut2, OccupiedEntry, OrderMap, VacantEntry};
 use core::hash::{BuildHasher, Hash};
 use indexmap::map::MutableEntryKey as _;
 use indexmap::map::MutableKeys as _;
@@ -35,6 +35,9 @@ pub trait MutableKeys: private::Sealed {
     /// Computes in **O(1)** time.
     fn get_index_mut2(&mut self, index: usize) -> Option<(&mut Self::Key, &mut Self::Value)>;
 
+    /// Return an iterator over the key-value pairs of the map, in their order
+    fn iter_mut2(&mut self) -> IterMut2<'_, Self::Key, Self::Value>;
+
     /// Scan through each key-value pair in the map and keep those where the
     /// closure `keep` returns `true`.
     ///
@@ -66,6 +69,10 @@ where
 
     fn get_index_mut2(&mut self, index: usize) -> Option<(&mut K, &mut V)> {
         self.inner.get_index_mut2(index)
+    }
+
+    fn iter_mut2(&mut self) -> IterMut2<'_, Self::Key, Self::Value> {
+        self.inner.iter_mut2()
     }
 
     fn retain2<F>(&mut self, keep: F)

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -494,6 +494,7 @@ fn iter_default() {
     }
     assert_default::<Iter<'static, K, V>>();
     assert_default::<IterMut<'static, K, V>>();
+    assert_default::<IterMut2<'static, K, V>>();
     assert_default::<IntoIter<K, V>>();
     assert_default::<Keys<'static, K, V>>();
     assert_default::<IntoKeys<K, V>>();


### PR DESCRIPTION
- Added trait `MutableEntryKey` for opt-in mutable access to map entry keys.
- Added method `MutableKeys::iter_mut2` for opt-in mutable iteration of map
  keys and values.
