### PR TITLE
Release 0.5.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "0.5.5"
+version = "0.5.6"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"
@@ -14,7 +14,7 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.7.1", default-features = false }
+indexmap = { version = "2.8.0", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rayon = { version = "1.9", optional = true }
 
 [dev-dependencies]
 itertools = "0.14"
-rand = {version = "0.8", features = ["small_rng"] }
+rand = {version = "0.9", features = ["small_rng"] }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
 lazy_static = "1.3"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 0.5.6 (2025-03-10)
+
+- Added `ordermap_with_default!` and `orderset_with_default!` to be used with
+  alternative hashers, especially when using the crate without `std`.
+- Updated the `indexmap` dependency to version 2.8.0.
+
 ## 0.5.5 (2025-01-19)
 
 - Added `#[track_caller]` to functions that may panic.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,8 @@
 //!   [`with_capacity_and_hasher`][OrderMap::with_capacity_and_hasher] instead.
 //!   A no-std compatible hasher will be needed as well, for example
 //!   from the crate `twox-hash`.
-//! - Macros [`ordermap!`] and [`orderset!`] are unavailable without `std`.
+//! - Macros [`ordermap!`] and [`orderset!`] are unavailable without `std`. Use
+//!   the macros [`ordermap_with_default!`] and [`orderset_with_default!`] instead.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,40 @@
+/// Create an [`OrderMap`][crate::OrderMap] from a list of key-value pairs
+/// and a `BuildHasherDefault`-wrapped custom hasher.
+///
+/// ## Example
+///
+/// ```
+/// use ordermap::ordermap_with_default;
+/// use fnv::FnvHasher;
+///
+/// let map = ordermap_with_default!{
+///     FnvHasher;
+///     "a" => 1,
+///     "b" => 2,
+/// };
+/// assert_eq!(map["a"], 1);
+/// assert_eq!(map["b"], 2);
+/// assert_eq!(map.get("c"), None);
+///
+/// // "a" is the first key
+/// assert_eq!(map.keys().next(), Some(&"a"));
+/// ```
+#[macro_export]
+macro_rules! ordermap_with_default {
+    ($H:ty; $($key:expr => $value:expr,)+) => { $crate::ordermap_with_default!($H; $($key => $value),+) };
+    ($H:ty; $($key:expr => $value:expr),*) => {{
+        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
+        #[allow(unused_mut)]
+        // Specify your custom `H` (must implement Default + Hasher) as the hasher:
+        let mut map = $crate::OrderMap::with_capacity_and_hasher(CAP, builder);
+        $(
+            map.insert($key, $value);
+        )*
+        map
+    }};
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[macro_export]
@@ -33,6 +70,43 @@ macro_rules! ordermap {
             map
         }
     };
+}
+
+/// Create an [`OrderSet`][crate::OrderSet] from a list of values
+/// and a `BuildHasherDefault`-wrapped custom hasher.
+///
+/// ## Example
+///
+/// ```
+/// use ordermap::orderset_with_default;
+/// use fnv::FnvHasher;
+///
+/// let set = orderset_with_default!{
+///     FnvHasher;
+///     "a",
+///     "b",
+/// };
+/// assert!(set.contains("a"));
+/// assert!(set.contains("b"));
+/// assert!(!set.contains("c"));
+///
+/// // "a" is the first value
+/// assert_eq!(set.iter().next(), Some(&"a"));
+/// ```
+#[macro_export]
+macro_rules! orderset_with_default {
+    ($H:ty; $($value:expr,)+) => { $crate::orderset_with_default!($H; $($value),+) };
+    ($H:ty; $($value:expr),*) => {{
+        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
+        #[allow(unused_mut)]
+        // Specify your custom `H` (must implement Default + Hash) as the hasher:
+        let mut set = $crate::OrderSet::with_capacity_and_hasher(CAP, builder);
+        $(
+            set.insert($value);
+        )*
+        set
+    }};
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
- Added `ordermap_with_default!` and `orderset_with_default!` to be used with
  alternative hashers, especially when using the crate without `std`.
- Updated the `indexmap` dependency to version 2.8.0.