### PR TITLE
Release 0.5.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.11.0", default-features = false }
+indexmap = { version = "2.11.1", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "0.5.9"
+version = "0.5.10"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 0.5.10 (2025-09-08)
+
+- Added a `get_key_value_mut` method to `OrderMap`.
+- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.
+
 ## 0.5.9 (2025-08-22)
 
 - Added `insert_sorted_by` and `insert_sorted_by_key` methods to `OrderMap`,

--- a/src/map.rs
+++ b/src/map.rs
@@ -736,7 +736,7 @@ where
         self.inner.contains_key(key)
     }
 
-    /// Return a reference to the value stored for `key`, if it is present,
+    /// Return a reference to the stored value for `key`, if it is present,
     /// else `None`.
     ///
     /// Computes in **O(1)** time (average).
@@ -747,7 +747,7 @@ where
         self.inner.get(key)
     }
 
-    /// Return references to the key-value pair stored for `key`,
+    /// Return references to the stored key-value pair for the lookup `key`,
     /// if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
@@ -758,7 +758,10 @@ where
         self.inner.get_key_value(key)
     }
 
-    /// Return item index, key and value
+    /// Return the index with references to the stored key-value pair for the
+    /// lookup `key`, if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_full<Q>(&self, key: &Q) -> Option<(usize, &K, &V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,
@@ -766,7 +769,7 @@ where
         self.inner.get_full(key)
     }
 
-    /// Return item index, if it exists in the map
+    /// Return the item index for `key`, if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
     pub fn get_index_of<Q>(&self, key: &Q) -> Option<usize>
@@ -776,6 +779,10 @@ where
         self.inner.get_index_of(key)
     }
 
+    /// Return a mutable reference to the stored value for `key`,
+    /// if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         Q: ?Sized + Hash + Equivalent<K>,
@@ -783,8 +790,8 @@ where
         self.inner.get_mut(key)
     }
 
-    /// Return references to the key-value pair stored for `key`,
-    /// if it is present, else `None`.
+    /// Return a reference and mutable references to the stored key-value pair
+    /// for the lookup `key`, if it is present, else `None`.
     ///
     /// Computes in **O(1)** time (average).
     pub fn get_key_value_mut<Q>(&mut self, key: &Q) -> Option<(&K, &mut V)>
@@ -794,6 +801,10 @@ where
         self.inner.get_key_value_mut(key)
     }
 
+    /// Return the index with a reference and mutable reference to the stored
+    /// key-value pair for the lookup `key`, if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
     pub fn get_full_mut<Q>(&mut self, key: &Q) -> Option<(usize, &K, &mut V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -783,6 +783,17 @@ where
         self.inner.get_mut(key)
     }
 
+    /// Return references to the key-value pair stored for `key`,
+    /// if it is present, else `None`.
+    ///
+    /// Computes in **O(1)** time (average).
+    pub fn get_key_value_mut<Q>(&mut self, key: &Q) -> Option<(&K, &mut V)>
+    where
+        Q: ?Sized + Hash + Equivalent<K>,
+    {
+        self.inner.get_key_value_mut(key)
+    }
+
     pub fn get_full_mut<Q>(&mut self, key: &Q) -> Option<(usize, &K, &mut V)>
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -480,7 +480,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, key: K, value: V, cmp: F) -> (usize, Option<V>)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         self.inner.insert_sorted_by(key, value, cmp)

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -338,7 +338,6 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(self, value: V, cmp: F) -> (usize, &'a mut V)
     where
-        K: Ord,
         F: FnMut(&K, &V, &K, &V) -> Ordering,
     {
         self.inner.insert_sorted_by(value, cmp)

--- a/src/set.rs
+++ b/src/set.rs
@@ -419,7 +419,6 @@ where
     /// Computes in **O(n)** time (average).
     pub fn insert_sorted_by<F>(&mut self, value: T, cmp: F) -> (usize, bool)
     where
-        T: Ord,
         F: FnMut(&T, &T) -> Ordering,
     {
         self.inner.insert_sorted_by(value, cmp)


### PR DESCRIPTION
- Added a `get_key_value_mut` method to `OrderMap`.
- Removed the unnecessary `Ord` bound on `insert_sorted_by` methods.