### PR TITLE
Release 0.5.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "0.5.10"
+version = "0.5.11"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,26 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.11.1", default-features = false }
+indexmap = { version = "2.11.2", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false }
+serde_core = { version = "1.0.220", optional = true, default-features = false }
 borsh = { version = "1.5.6", optional = true, default-features = false }
 rayon = { version = "1.9", optional = true }
 sval = { version = "2", optional = true, default-features = false }
+
+# serde v1.0.220 is the first version that released with `serde_core`.
+# This is required to avoid conflict with other `serde` users which may require an older version.
+[target.'cfg(any())'.dependencies]
+serde = { version = "1.0.220", default-features = false }
 
 [dev-dependencies]
 itertools = "0.14"
 fastrand = { version = "2", default-features = false }
 quickcheck = { version = "1.0", default-features = false }
 fnv = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]
@@ -37,7 +42,7 @@ std = ["indexmap/std"]
 arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]
 quickcheck = ["dep:quickcheck", "indexmap/quickcheck"]
 rayon = ["dep:rayon", "indexmap/rayon"]
-serde = ["dep:serde", "indexmap/serde"]
+serde = ["dep:serde_core", "indexmap/serde"]
 sval = ["dep:sval", "indexmap/sval"]
 borsh = ["dep:borsh", "borsh/indexmap"]
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 0.5.11 (2025-09-15)
+
+- Switched the "serde" feature to depend on `serde_core`, improving build
+  parallelism in cases where other dependents have enabled "serde/derive".
+
 ## 0.5.10 (2025-09-08)
 
 - Added a `get_key_value_mut` method to `OrderMap`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //! [`no_std`]: #no-standard-library-targets
-//! [`Serialize`]: `::serde::Serialize`
-//! [`Deserialize`]: `::serde::Deserialize`
+//! [`Serialize`]: `::serde_core::Serialize`
+//! [`Deserialize`]: `::serde_core::Deserialize`
 //! [`BorshSerialize`]: `::borsh::BorshSerialize`
 //! [`BorshDeserialize`]: `::borsh::BorshDeserialize`
 //! [`arbitrary::Arbitrary`]: `::arbitrary::Arbitrary`

--- a/src/map/serde_seq.rs
+++ b/src/map/serde_seq.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! # use ordermap::OrderMap;
-//! # use serde_derive::{Deserialize, Serialize};
+//! # use serde::{Deserialize, Serialize};
 //! #[derive(Deserialize, Serialize)]
 //! struct Data {
 //!     #[serde(with = "ordermap::map::serde_seq")]
@@ -21,8 +21,8 @@
 use crate::OrderMap;
 use core::hash::{BuildHasher, Hash};
 use indexmap::map::serde_seq as ix;
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
+use serde_core::de::{Deserialize, Deserializer};
+use serde_core::ser::{Serialize, Serializer};
 
 /// Serializes an [`OrderMap`] as an ordered sequence.
 ///
@@ -30,7 +30,7 @@ use serde::ser::{Serialize, Serializer};
 ///
 /// ```
 /// # use ordermap::OrderMap;
-/// # use serde_derive::Serialize;
+/// # use serde::Serialize;
 /// #[derive(Serialize)]
 /// struct Data {
 ///     #[serde(serialize_with = "ordermap::map::serde_seq::serialize")]
@@ -53,7 +53,7 @@ where
 ///
 /// ```
 /// # use ordermap::OrderMap;
-/// # use serde_derive::Deserialize;
+/// # use serde::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Data {
 ///     #[serde(deserialize_with = "ordermap::map::serde_seq::deserialize")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,9 +2,9 @@
 
 use crate::{OrderMap, OrderSet};
 use core::hash::{BuildHasher, Hash};
-use serde::de::value::{MapDeserializer, SeqDeserializer};
-use serde::de::{Deserialize, Deserializer, Error, IntoDeserializer};
-use serde::ser::{Serialize, Serializer};
+use serde_core::de::value::{MapDeserializer, SeqDeserializer};
+use serde_core::de::{Deserialize, Deserializer, Error, IntoDeserializer};
+use serde_core::ser::{Serialize, Serializer};
 
 impl<K, V, S> Serialize for OrderMap<K, V, S>
 where


### PR DESCRIPTION
- Switched the "serde" feature to depend on `serde_core`, improving build
  parallelism in cases where other dependents have enabled "serde/derive".