### PR TITLE
Release 0.5.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "0.5.11"
+version = "0.5.12"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"
@@ -14,7 +14,7 @@ rust-version = "1.63"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.11.2", default-features = false }
+indexmap = { version = "2.11.3", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
@@ -26,7 +26,7 @@ sval = { version = "2", optional = true, default-features = false }
 # serde v1.0.220 is the first version that released with `serde_core`.
 # This is required to avoid conflict with other `serde` users which may require an older version.
 [target.'cfg(any())'.dependencies]
-serde = { version = "1.0.220", default-features = false }
+serde = { version = "1.0.220", default-features = false, optional = true }
 
 [dev-dependencies]
 itertools = "0.14"
@@ -42,7 +42,7 @@ std = ["indexmap/std"]
 arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]
 quickcheck = ["dep:quickcheck", "indexmap/quickcheck"]
 rayon = ["dep:rayon", "indexmap/rayon"]
-serde = ["dep:serde_core", "indexmap/serde"]
+serde = ["dep:serde_core", "dep:serde", "indexmap/serde"]
 sval = ["dep:sval", "indexmap/sval"]
 borsh = ["dep:borsh", "borsh/indexmap"]
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 0.5.12 (2025-09-15)
+
+- Make the minimum `serde` version only apply when "serde" is enabled.
+
 ## 0.5.11 (2025-09-15)
 
 - Switched the "serde" feature to depend on `serde_core`, improving build


### PR DESCRIPTION
- Make the minimum `serde` version only apply when "serde" is enabled.