### PR TITLE
Release 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ordermap"
 edition = "2021"
-version = "1.0.0"
+version = "1.1.0"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"
@@ -14,7 +14,7 @@ rust-version = "1.82"
 bench = false
 
 [dependencies]
-indexmap = { version = "2.12.0", default-features = false }
+indexmap = { version = "2.13.0", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Releases
 
+## 1.1.0 (2026-01-07)
+
+- Updated the `indexmap` dependency to version 2.13.0 for new features:
+  - Implemented `Clone` for `IntoKeys` and `IntoValues`.
+  - Added `map::Slice::split_at_checked` and `split_at_mut_checked`.
+  - Added `set::Slice::split_at_checked`.
+
 ## 1.0.0 (2025-10-17)
 
 - **MSRV**: Rust 1.82.0 or later is now required.


### PR DESCRIPTION
- Updated the `indexmap` dependency to version 2.13.0 for new features:
  - Implemented `Clone` for `IntoKeys` and `IntoValues`.
  - Added `map::Slice::split_at_checked` and `split_at_mut_checked`.
  - Added `set::Slice::split_at_checked`.