### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.82.0 # MSRV
+          - rust: 1.85.0 # MSRV
             features:
           - rust: stable
             features: arbitrary
@@ -40,12 +40,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Lock MSRV-compatible dependencies
-        if: matrix.rust == '1.82.0'
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
-        # Note that this uses the runner's pre-installed stable cargo
-        run: cargo generate-lockfile
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -72,19 +66,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.82.0
+          - rust: 1.85.0
             target: thumbv6m-none-eabi
           - rust: stable
             target: thumbv6m-none-eabi
 
     steps:
       - uses: actions/checkout@v4
-      - name: Lock MSRV-compatible dependencies
-        if: matrix.rust == '1.82.0'
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
-        # Note that this uses the runner's pre-installed stable cargo
-        run: cargo generate-lockfile
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -124,14 +112,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: dtolnay/rust-toolchain@1.82.0 # MSRV
+      - uses: dtolnay/rust-toolchain@1.85.0 # MSRV
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
       - name: Lock minimal direct dependencies
         run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z direct-minimal-versions
-        env:
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Build (nightly)
         run: cargo +nightly build --verbose --all-features
       - name: Build (MSRV)

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "ordermap"
-edition = "2021"
-version = "1.1.0"
+edition = "2024"
+version = "1.2.0"
 documentation = "https://docs.rs/ordermap/"
 repository = "https://github.com/indexmap-rs/ordermap"
 license = "Apache-2.0 OR MIT"
 description = "A hash table with consistent order and fast iteration."
 keywords = ["hashmap", "no_std"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.82"
+rust-version = "1.85"
 
 [lib]
 bench = false
 
 [dependencies]
-indexmap = { version = "2.13.0", default-features = false }
+indexmap = { version = "2.14.0", default-features = false }
 
 arbitrary = { version = "1.0", optional = true, default-features = false }
 quickcheck = { version = "1.0", optional = true, default-features = false }
@@ -31,7 +31,9 @@ serde = { version = "1.0.220", default-features = false, optional = true }
 [dev-dependencies]
 itertools = "0.14"
 fastrand = { version = "2", default-features = false }
-quickcheck = { version = "1.0", default-features = false }
+# There's a false dependency cycle in indexmap/quickcheck with 1.1:
+# https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/cycle.20with.20.60indexmap.2Fquickcheck.60/with/583611414
+quickcheck = { version = "~1.0", default-features = false }
 fnv = "1.0"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build status](https://github.com/indexmap-rs/ordermap/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/indexmap-rs/ordermap/actions)
 [![crates.io](https://img.shields.io/crates/v/ordermap.svg)](https://crates.io/crates/ordermap)
 [![docs](https://docs.rs/ordermap/badge.svg)](https://docs.rs/ordermap)
-[![rustc](https://img.shields.io/badge/rust-1.82%2B-orange.svg)](https://img.shields.io/badge/rust-1.82%2B-orange.svg)
+[![rustc](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://img.shields.io/badge/rust-1.85%2B-orange.svg)
 
 A pure-Rust hash table which preserves (in a limited sense) insertion order.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Releases
 
+## 1.2.0 (2026-02-09)
+
+- **MSRV**: Rust 1.85.0 or later is now required.
+- Updated the `indexmap` dependency to version 2.14.0.
+  - New features include `const`-ified methods on `Slice` types.
+
 ## 1.1.0 (2026-01-07)
 
 - Updated the `indexmap` dependency to version 2.13.0 for new features:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! ### Rust Version
 //!
-//! This version of ordermap requires Rust 1.82 or later.
+//! This version of ordermap requires Rust 1.85 or later.
 //!
 //! The ordermap 1.x release series will use a carefully considered version
 //! upgrade policy, where in a later 1.x version, we will raise the minimum

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@
 macro_rules! ordermap_with_default {
     ($H:ty; $($key:expr => $value:expr,)+) => { $crate::ordermap_with_default!($H; $($key => $value),+) };
     ($H:ty; $($key:expr => $value:expr),*) => {{
-        let builder = ::core::hash::BuildHasherDefault::<$H>::default();
+        let builder = ::core::hash::BuildHasherDefault::<$H>::new();
         const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
         #[allow(unused_mut)]
         // Specify your custom `H` (must implement Default + Hasher) as the hasher:

--- a/src/map.rs
+++ b/src/map.rs
@@ -812,7 +812,9 @@ where
         self.inner.get_full_mut(key)
     }
 
-    /// Return the values for `N` keys. If any key is duplicated, this function will panic.
+    /// Return the values for `N` keys.
+    ///
+    /// ***Panics*** if any key is duplicated.
     ///
     /// # Examples
     ///
@@ -820,6 +822,7 @@ where
     /// let mut map = ordermap::OrderMap::from([(1, 'a'), (3, 'b'), (2, 'c')]);
     /// assert_eq!(map.get_disjoint_mut([&2, &1]), [Some(&mut 'c'), Some(&mut 'a')]);
     /// ```
+    #[track_caller]
     pub fn get_disjoint_mut<Q, const N: usize>(&mut self, keys: [&Q; N]) -> [Option<&mut V>; N]
     where
         Q: ?Sized + Hash + Equivalent<K>,

--- a/src/map/raw_entry_v1.rs
+++ b/src/map/raw_entry_v1.rs
@@ -12,8 +12,8 @@
 use crate::{Equivalent, OrderMap};
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
-use indexmap::map::raw_entry_v1 as ix;
 use indexmap::map::RawEntryApiV1 as _;
+use indexmap::map::raw_entry_v1 as ix;
 
 #[cfg(doc)]
 use alloc::vec::Vec;

--- a/test-nostd/Cargo.toml
+++ b/test-nostd/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-nostd"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies.ordermap]
 path = ".."

--- a/test-serde/Cargo.toml
+++ b/test-serde/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-serde"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/test-serde/src/lib.rs
+++ b/test-serde/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use fnv::FnvBuildHasher;
-use ordermap::{ordermap, orderset, OrderMap, OrderSet};
+use ordermap::{OrderMap, OrderSet, ordermap, orderset};
 use serde::{Deserialize, Serialize};
-use serde_test::{assert_tokens, Token};
+use serde_test::{Token, assert_tokens};
 
 #[test]
 fn test_serde_map() {

--- a/test-sval/Cargo.toml
+++ b/test-sval/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "test-sval"
-version = "0.1.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 

--- a/test-sval/src/lib.rs
+++ b/test-sval/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
 use fnv::FnvBuildHasher;
-use ordermap::{ordermap, orderset, OrderMap, OrderSet};
-use sval_test::{assert_tokens, Token};
+use ordermap::{OrderMap, OrderSet, ordermap, orderset};
+use sval_test::{Token, assert_tokens};
 
 #[test]
 fn test_sval_map() {

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,5 +1,5 @@
-use ordermap::ordermap;
 use ordermap::Equivalent;
+use ordermap::ordermap;
 
 use std::hash::Hash;
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -518,10 +518,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 
@@ -545,10 +546,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 
@@ -574,10 +576,11 @@ where
 
     // Check both iteration order and hash lookups
     assert!(map.keys().eq(vec.iter()));
-    assert!(vec
-        .iter()
-        .enumerate()
-        .all(|(i, x)| { map.get_index_of(x) == Some(i) }));
+    assert!(
+        vec.iter()
+            .enumerate()
+            .all(|(i, x)| { map.get_index_of(x) == Some(i) })
+    );
     TestResult::passed()
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -61,7 +61,7 @@ macro_rules! quickcheck_limit {
                     let mut quickcheck = QuickCheck::new();
                     if cfg!(miri) {
                         quickcheck = quickcheck
-                            .gen(Gen::new(10))
+                            .r#gen(Gen::new(10))
                             .tests(10)
                             .max_tests(100);
                     }
@@ -164,7 +164,7 @@ quickcheck_limit! {
                 }
             }
         }
-        let hsorted = hmap.iter().sorted_by_key(|(&k, _)| (k.unsigned_abs(), k));
+        let hsorted = hmap.iter().sorted_by_key(|&(&k, _)| (k.unsigned_abs(), k));
         itertools::assert_equal(hsorted, &map);
         itertools::assert_equal(&map, &map2);
         true


### PR DESCRIPTION
- **MSRV**: Rust 1.85.0 or later is now required.
- Updated the `indexmap` dependency to version 2.14.0.
  - New features include `const`-ified methods on `Slice` types.